### PR TITLE
adding cloud-config example for linux vm autoscaling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 windows_vms/dist
+*.swp

--- a/linux_vms/README.md
+++ b/linux_vms/README.md
@@ -24,3 +24,6 @@ echo "${{VARIABLE}}"
 The example script [ubuntu.sh](./ubuntu.sh) installs KasmVNC on the Ubuntu VM and configures a KasmVNC user using the configured username and password in the [auto-scale configuration's](https://docs.kasm.com/docs/guide/compute/pools.html#autoscale-configurations) Connection User and Connection Password fields. Kasm Workspaces can also work with a traditional VNC server. The example ubuntu.sh script also includes a function for installing, configuring, and starting tigervnc on the default port 5901.
 
 Additional KasmVNC installers for other distros can be found on the public [KasmVNC github repository](https://github.com/kasmtech/KasmVNC/releases)
+
+### cloud-config.yaml
+This is a default cloud init configuation that can be used as a startup script for Ubuntu servers running on Harvester/KubeVirt platforms.

--- a/linux_vms/cloud-config.yaml
+++ b/linux_vms/cloud-config.yaml
@@ -1,0 +1,47 @@
+#cloud-config
+package_update: true
+packages:
+  - qemu-guest-agent
+  - sudo
+users:
+  - name: kasm-admin
+    shell: /bin/bash
+    lock_passwd: true
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh_authorized_keys:
+      - {ssh_key}
+
+write_files:
+  - path: /usr/local/bin/server-check-in.sh
+    permissions: '0755'
+    content: |
+      #!/bin/bash
+      curl -k -X POST -H "Content-Type: application/json" -d '{{"status": "running", "status_message": "Initialization Complete", "status_progress": "100"}}' https://{upstream_auth_address}/api/set_server_status?token={checkin_jwt}
+  - path: /etc/systemd/system/server-checkin.service
+    content: |
+      [Unit]
+      Description=Kasm Server Check-in
+
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/local/bin/server-check-in.sh
+  - path: /etc/systemd/system/server-checkin.timer
+    content: |
+      [Unit]
+      Description=Run Kasm Server Check-in every 30 seconds
+
+      [Timer]
+      OnBootSec=20
+      OnUnitActiveSec=30s
+
+      [Install]
+      WantedBy=timers.target
+runcmd:
+  - - systemctl
+    - enable
+    - --now
+    - qemu-guest-agent.service
+  - sleep 15
+  - systemctl daemon-reload
+  - systemctl enable server-checkin.timer
+  - systemctl start server-checkin.timer


### PR DESCRIPTION
This is a cloud config example for Linux VM Autoscaling.

It uses a simple systemd service, that uses systemd timer, to send check-in messages to Kasm via a curl command.